### PR TITLE
Delete unnecessary global variables that override definitions

### DIFF
--- a/rotary_encoder.go
+++ b/rotary_encoder.go
@@ -8,7 +8,6 @@ import (
 
 var (
 	states = []int8{0, -1, 1, 0, 1, 0, 0, -1, -1, 0, 0, 1, 0, 1, -1, 0}
-	enc    = New(machine.ROT_A, machine.ROT_B)
 )
 
 func New(pinA, pinB machine.Pin) *Device {


### PR DESCRIPTION
I created this Pull request as a suggestion.

Deleted unnecessary declarations using `machine.ROT_*` which are only owned by some boards and remain in this package.
This makes it possible, for example, to use this package in packages that are referenced by both boards that have `machine.ROT_*` and boards that do not.

Furthermore, parameters other than the above, such as `machine.Pin*`, should be designed so that they are passed by the package user, but this pull request does not change that much. .

Thank you for your cool work and attractive package!!